### PR TITLE
Improve Java interop

### DIFF
--- a/src/main/kotlin/com/statsig/sdk/Statsig.kt
+++ b/src/main/kotlin/com/statsig/sdk/Statsig.kt
@@ -228,7 +228,7 @@ class Statsig {
 }
 
 /**
- * A SAM for Java compatability
+ * A SAM for Java compatibility
  */
 @FunctionalInterface
 fun interface LayerExposureCallback {


### PR DESCRIPTION
This is an ABI breaking change.
Example change to address Java consumption of library.

The value of this PR is twofold 

1. Java consumers will not need to return Unit.Instance in their lambdas
```
                Statsig.getLayerWithCustomExposureLoggingAsync(
                        user,
                        layerName,
                        (layerExposureEventData) -> {
                            onExposure.accept(layerExposureEventData);
                            return Unit.INSTANCE;
                        }),
```
2. More importantly we can stop bringing Kotlin std-lib into the consumer's compile classpath

Reference: https://developer.android.com/kotlin/interop#lambda_arguments
