### PR TITLE
Add entity type to APIConfig

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.statsig.serversdk
 POM_ARTIFACT_ID=serversdk
-VERSION_NAME=1.2.2
+VERSION_NAME=1.2.3
 
 POM_NAME=Statsig Server SDK
 POM_DESCRIPTION=A feature gating and a/b testing library for statsig

--- a/src/main/kotlin/com/statsig/sdk/DataTypes.kt
+++ b/src/main/kotlin/com/statsig/sdk/DataTypes.kt
@@ -21,6 +21,7 @@ internal data class APIConfig(
     @SerializedName("enabled") val enabled: Boolean,
     @SerializedName("rules") val rules: Array<APIRule>,
     @SerializedName("idType") val idType: String,
+    @SerializedName("entity") val entity: String,
     @SerializedName("explicitParameters") val explicitParameters: Array<String>?,
 )
 

--- a/src/main/kotlin/com/statsig/sdk/StatsigMetadata.kt
+++ b/src/main/kotlin/com/statsig/sdk/StatsigMetadata.kt
@@ -2,7 +2,7 @@ package com.statsig.sdk
 
 import java.util.Properties
 
-private const val VERSION = "1.2.2"
+private const val VERSION = "1.2.3"
 
 internal class StatsigMetadata {
     companion object {


### PR DESCRIPTION
to differentiate between gates/holdouts/segments and dynamic configs/experiments