### PR TITLE
[SECURITY - CRITICAL] Fix CVE-2022-1471 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("com.github.ua-parser:uap-java:1.5.3")
+    implementation("com.github.ua-parser:uap-java:1.5.4")
     implementation("com.statsig:ip3country:0.1.4")
 }
 


### PR DESCRIPTION
Fixes CVE-2022-1471 affecting transitive dependency uap-java -> snakeyaml

See: 
https://nvd.nist.gov/vuln/detail/CVE-2022-1471
https://github.com/ua-parser/uap-java/releases/tag/v1.5.4
