### PR TITLE
Shortcut hash computation for constant rules

### DIFF
--- a/src/main/kotlin/com/statsig/sdk/Evaluator.kt
+++ b/src/main/kotlin/com/statsig/sdk/Evaluator.kt
@@ -315,7 +315,11 @@ internal class Evaluator(
                     return
                 }
 
-                val pass =
+                val pass = if (rule.passPercentage == 0.0) {
+                    false
+                } else if (rule.passPercentage == 100.0){
+                    true
+                } else {
                     computeUserHash(
                         config.salt +
                             '.' +
@@ -324,6 +328,7 @@ internal class Evaluator(
                             (getUnitID(ctx.user, rule.idType) ?: Const.EMPTY_STR),
                     )
                         .mod(10000UL) < (rule.passPercentage.times(100.0)).toULong()
+                }
 
                 if (!pass) {
                     ctx.evaluation.jsonValue = config.defaultValue


### PR DESCRIPTION
I noticed that this implementation is always computing the per-rule hash. Most targetting cases are either including or excluding all users which pass the condition. 

Shortcutting these always pass / always fail cases will substantially reduce the number of string concatenation and hashing operations performed in this hot loop of rule evaluation.