### PR TITLE
optimize gson usage

### DIFF
--- a/src/main/kotlin/com/statsig/sdk/DynamicConfig.kt
+++ b/src/main/kotlin/com/statsig/sdk/DynamicConfig.kt
@@ -1,7 +1,5 @@
 package com.statsig.sdk
 
-import com.google.gson.Gson
-
 /**
  * A helper class for interfacing with Dynamic Configs defined in the Statsig console
  */
@@ -132,7 +130,7 @@ class DynamicConfig(
     }
 
     fun getExposureMetadata(): String {
-        return Gson().toJson(
+        return Utils.PLAIN_GSON.toJson(
             mapOf(
                 "config" to this.name,
                 "ruleID" to this.ruleID,

--- a/src/main/kotlin/com/statsig/sdk/ErrorBoundary.kt
+++ b/src/main/kotlin/com/statsig/sdk/ErrorBoundary.kt
@@ -1,6 +1,5 @@
 package com.statsig.sdk
 
-import com.google.gson.Gson
 import kotlinx.coroutines.*
 import okhttp3.Call
 import okhttp3.Callback
@@ -93,7 +92,7 @@ internal class ErrorBoundary(private val apiKey: String, private val options: St
                 if (safeInfo.length > maxInfoLength) {
                     safeInfo = safeInfo.substring(0, maxInfoLength)
                 }
-                val optionsCopy = Gson().toJson(options.getLoggingCopy())
+                val optionsCopy = Utils.PLAIN_GSON.toJson(options.getLoggingCopy())
                 val body = """{
                 "tag": "$tag",
                 "exception": "${ex.javaClass.name}",

--- a/src/main/kotlin/com/statsig/sdk/Evaluator.kt
+++ b/src/main/kotlin/com/statsig/sdk/Evaluator.kt
@@ -42,7 +42,6 @@ internal class Evaluator(
     private var configOverrides: MutableMap<String, Map<String, Any>> = HashMap()
     private var layerOverrides: MutableMap<String, Map<String, Any>> = HashMap()
     private var hashLookupTable: MutableMap<String, ULong> = HashMap()
-    private val gson = Utils.getGson()
     private val logger = options.customLogger
 
     private val calendarOne = Calendar.getInstance()

--- a/src/main/kotlin/com/statsig/sdk/Hashing.kt
+++ b/src/main/kotlin/com/statsig/sdk/Hashing.kt
@@ -1,6 +1,5 @@
 package com.statsig.sdk
 
-import com.google.gson.Gson
 import java.security.MessageDigest
 import java.util.Base64
 
@@ -22,8 +21,7 @@ class Hashing {
         }
 
         fun djb2ForMap(map: Map<String, Any>): String {
-            val gson = Gson()
-            return djb2(gson.toJson(Utils.sortMap(map)))
+            return djb2(Utils.PLAIN_GSON.toJson(Utils.sortMap(map)))
         }
 
         fun sha256(input: String): String {

--- a/src/main/kotlin/com/statsig/sdk/Layer.kt
+++ b/src/main/kotlin/com/statsig/sdk/Layer.kt
@@ -1,7 +1,5 @@
 package com.statsig.sdk
 
-import com.google.gson.Gson
-
 typealias OnLayerExposure = (layerExposureEventData: LayerExposureEventData) -> Unit
 internal typealias OnLayerExposureInternal = (layer: Layer, parameterName: String) -> Unit
 
@@ -125,7 +123,7 @@ class Layer internal constructor(
      * Legacy exposure data at the layer level. Should NOT be used in new code as this will cause over exposure.
      */
     fun getLegacyExposureMetadata(): String {
-        return Gson().toJson(
+        return Utils.PLAIN_GSON.toJson(
             mapOf(
                 "config" to this.name,
                 "ruleID" to this.ruleID,

--- a/src/main/kotlin/com/statsig/sdk/StatsigLogger.kt
+++ b/src/main/kotlin/com/statsig/sdk/StatsigLogger.kt
@@ -54,7 +54,6 @@ internal class StatsigLogger(
             deduper.clear()
         }
     }
-    private val gson = Utils.getGson()
     internal var diagnostics: Diagnostics? = null
     private var eventQueueSize: Int? = null
     private val logger = statsigOptions.customLogger
@@ -181,8 +180,8 @@ internal class StatsigLogger(
         val event = StatsigEvent(DIAGNOSTICS_EVENT)
         event.eventMetadata = mapOf(
             "context" to context.toString().lowercase(),
-            "markers" to gson.toJson(markers),
-            "statsigOptions" to gson.toJson(statsigOptions.getLoggingCopy()),
+            "markers" to Utils.GSON.toJson(markers),
+            "statsigOptions" to Utils.GSON.toJson(statsigOptions.getLoggingCopy()),
         )
         log(event)
     }
@@ -198,7 +197,7 @@ internal class StatsigLogger(
         val event = StatsigEvent(DIAGNOSTICS_EVENT)
         event.eventMetadata = mapOf(
             "context" to context.name.lowercase(),
-            "markers" to gson.toJson(markers),
+            "markers" to Utils.GSON.toJson(markers),
         )
         if (statsigOptions.disableAllLogging) {
             return

--- a/src/main/kotlin/com/statsig/sdk/StatsigMetadata.kt
+++ b/src/main/kotlin/com/statsig/sdk/StatsigMetadata.kt
@@ -18,7 +18,6 @@ internal data class StatsigMetadata(@SerializedName("sdkType") var sdkType: Stri
         VERSION
     }
     fun asJson(): String {
-        val gson = Utils.getGson()
-        return gson.toJson(this)
+        return Utils.GSON.toJson(this)
     }
 }

--- a/src/main/kotlin/com/statsig/sdk/StatsigServer.kt
+++ b/src/main/kotlin/com/statsig/sdk/StatsigServer.kt
@@ -273,8 +273,6 @@ sealed class StatsigServer {
 private class StatsigServerImpl() :
     StatsigServer() {
 
-    private val gson = Utils.getGson()
-
     override lateinit var errorBoundary: ErrorBoundary
     private lateinit var coroutineExceptionHandler: CoroutineExceptionHandler
     private lateinit var statsigJob: CompletableJob
@@ -1228,7 +1226,7 @@ private class StatsigServerImpl() :
                             normalizedUser,
                             layer,
                             paramName,
-                            gson.toJson(metadata),
+                            Utils.GSON.toJson(metadata),
                         ),
                     )
                 } else {

--- a/src/main/kotlin/com/statsig/sdk/Utils.kt
+++ b/src/main/kotlin/com/statsig/sdk/Utils.kt
@@ -2,14 +2,18 @@ package com.statsig.sdk
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.ToNumberPolicy
+import com.google.gson.reflect.TypeToken
 import java.util.*
+
+inline fun <reified T> Gson.fromJson(json: String): T = fromJson(json, object : TypeToken<T>() {}.type)
 
 internal class Utils {
     companion object {
         fun getTimeInMillis(): Long {
             return System.currentTimeMillis()
         }
-        fun getGson(): Gson = GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create()
+        val GSON: Gson = GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create()
+        val PLAIN_GSON = Gson()
         fun toStringOrEmpty(value: Any?): String {
             return value?.toString() ?: ""
         }

--- a/src/main/kotlin/com/statsig/sdk/network/HTTPHelper.kt
+++ b/src/main/kotlin/com/statsig/sdk/network/HTTPHelper.kt
@@ -16,7 +16,6 @@ internal class HTTPHelper(
     private var diagnostics: Diagnostics? = null
     private val logger = options.customLogger
 
-    private val gson = Utils.getGson()
     private val json: MediaType = "application/json; charset=utf-8".toMediaType()
 
     fun setDiagnostics(diagnostics: Diagnostics) {
@@ -34,7 +33,7 @@ internal class HTTPHelper(
             val request = Request.Builder()
                 .url(url)
             if (body != null) {
-                val bodyJson = gson.toJson(body)
+                val bodyJson = Utils.GSON.toJson(body)
                 request.post(bodyJson.toRequestBody(json))
             }
             headers.forEach { (key, value) -> request.addHeader(key, value) }

--- a/src/main/kotlin/com/statsig/sdk/network/HTTPWorker.kt
+++ b/src/main/kotlin/com/statsig/sdk/network/HTTPWorker.kt
@@ -1,8 +1,6 @@
 package com.statsig.sdk.network
 
-import com.google.gson.Gson
 import com.google.gson.JsonParseException
-import com.google.gson.reflect.TypeToken
 import com.statsig.sdk.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
@@ -55,15 +53,12 @@ internal class HTTPWorker(
 
     private val json: MediaType = "application/json; charset=utf-8".toMediaType()
     private val statsigHttpClient: OkHttpClient
-    private val gson = Utils.getGson()
     private var diagnostics: Diagnostics? = null
     private val logger = options.customLogger
     val apiForDownloadConfigSpecs = options.endpointProxyConfigs[NetworkEndpoint.DOWNLOAD_CONFIG_SPECS]?.proxyAddress ?: options.apiForDownloadConfigSpecs ?: options.api ?: STATSIG_CDN_URL_BASE
     val apiForGetIDLists = options.endpointProxyConfigs[NetworkEndpoint.GET_ID_LISTS]?.proxyAddress ?: options.apiForGetIdlists ?: options.api ?: STATSIG_API_URL_BASE
     val apiForLogEvent = options.endpointProxyConfigs[NetworkEndpoint.LOG_EVENT]?.proxyAddress ?: options.api ?: STATSIG_API_URL_BASE
     private var eventsCount: String = ""
-
-    private inline fun <reified T> Gson.fromJson(json: String) = fromJson<T>(json, object : TypeToken<T>() {}.type)
 
     init {
         val clientBuilder = OkHttpClient.Builder()
@@ -281,7 +276,7 @@ internal class HTTPWorker(
             return
         }
 
-        val bodyJson = gson.toJson(mapOf("events" to events, "statsigMetadata" to statsigMetadata))
+        val bodyJson = Utils.GSON.toJson(mapOf("events" to events, "statsigMetadata" to statsigMetadata))
         val requestBody: RequestBody = bodyJson.toRequestBody(json)
         eventsCount = events.size.toString()
 


### PR DESCRIPTION
refactor all usages of the `Gson` object to use a singleton instance - sparing costly initialization, which has resulted in major performance implications for our clients.

this is a known optimization as `Gson` instances are stateless and thread-safe ("Gson instances are Thread-safe so you can reuse them freely across multiple threads" https://www.javadoc.io/doc/com.google.code.gson/gson/2.9.0/com.google.gson/com/google/gson/Gson.html) 

https://stackoverflow.com/questions/31432758/should-i-reuse-one-instance-of-gson-or-create-new-ones-on-demand
https://stackoverflow.com/questions/10380835/is-it-ok-to-use-gson-instance-as-a-static-field-in-a-model-bean-reuse

tests and lint pass.