### PR TITLE
Handling SecurityException Security manager does not allow for static UncaughtExceptionHandler modification

### DIFF
--- a/src/main/kotlin/com/statsig/sdk/StatsigServer.kt
+++ b/src/main/kotlin/com/statsig/sdk/StatsigServer.kt
@@ -307,8 +307,13 @@ private class StatsigServerImpl() :
 
     override fun setup(serverSecret: String, options: StatsigOptions) {
         try {
+          try {
             Thread.setDefaultUncaughtExceptionHandler(MainThreadExceptionHandler(this, Thread.currentThread()))
-            setupStartTime = System.currentTimeMillis()
+          } catch (_: SecurityException) {
+              options.customLogger.warn("[StatsigServer] Failed to set defaultUncaughtExceptionHandler, " +
+               "not using MainThreadExceptionHandler")
+          }
+          setupStartTime = System.currentTimeMillis()
             errorBoundary = ErrorBoundary(serverSecret, options, statsigMetadata)
             coroutineExceptionHandler = CoroutineExceptionHandler { _, ex ->
                 // no-op - supervisor job should not throw when a child fails


### PR DESCRIPTION
Hi, I am Diego Ocampo from Atlassian.

Statsig server init. setting Thread (static) DefaultUncaughtExceptionHandler is causing issues. The issues come from the fact that an uncaught exception that is completely unrelated to Statsig can end up shutting down Statsig background jobs.

Also, the MainThreadExceptionHandler is re-throwing the exception, which shouldnt be done as documented in: 

https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setDefaultUncaughtExceptionHandler-java.lang.Thread.UncaughtExceptionHandler-


> Note that the default uncaught exception handler should not usually defer to the thread's ThreadGroup object, as that could cause infinite recursion.

By re-throwing, the exception is then handled by ThreadGroup, which ends up calling Thread.UncaughtExceptionHandler in an infinite loop, eventually killing the thread.

In this PR I am adding a graceful exception handling for security permissions so we can initialise the application and restrict Statsig from setting this top level handler, which is problematic. 

https://github.com/statsig-io/java-server-sdk/issues/41
