### PR TITLE
Removing the problematic MainThreadExceptionHandler

### DIFF
--- a/src/main/kotlin/com/statsig/sdk/StatsigServer.kt
+++ b/src/main/kotlin/com/statsig/sdk/StatsigServer.kt
@@ -307,8 +307,7 @@ private class StatsigServerImpl() :
 
     override fun setup(serverSecret: String, options: StatsigOptions) {
         try {
-            Thread.setDefaultUncaughtExceptionHandler(MainThreadExceptionHandler(this, Thread.currentThread()))
-            setupStartTime = System.currentTimeMillis()
+          setupStartTime = System.currentTimeMillis()
             errorBoundary = ErrorBoundary(serverSecret, options, statsigMetadata)
             coroutineExceptionHandler = CoroutineExceptionHandler { _, ex ->
                 // no-op - supervisor job should not throw when a child fails
@@ -1429,18 +1428,5 @@ private class StatsigServerImpl() :
         diagnostics?.markEnd(KeyType.OVERALL, success)
         diagnostics?.logDiagnostics(ContextType.INITIALIZE)
         diagnostics.diagnosticsContext = ContextType.CONFIG_SYNC
-    }
-
-    class MainThreadExceptionHandler(val server: StatsigServer, val currentThread: Thread) :
-        Thread.UncaughtExceptionHandler {
-        override fun uncaughtException(t: Thread, e: Throwable) {
-            if (!t.name.equals(currentThread.name)) {
-                throw e
-            }
-            server.getCustomLogger()
-                .info("[StatsigServer] Shutting down Statsig because of unhandled exception from your server")
-            server.shutdown()
-            throw e
-        }
     }
 }


### PR DESCRIPTION
Setting defaultUncaughtExceptionHandler on static thread level is problematic:

- Means that Statig is changing this setting for the host application, replacing the handler that such application had already defined.
- Host application can anyways replace this after initialisation, meaning this handler will not be used.
- This top level error handler re-throws the exception, which is explicitly advised no to do so on Java documentation:

> Note that the default uncaught exception handler should not usually defer to the thread's ThreadGroup object, as that could cause infinite recursion.

This is causing unhandled exceptions to terminate threads and causing issues on host application on exceptions that are completely unrelated to Statsig. 

See [docs](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setDefaultUncaughtExceptionHandler-java.lang.Thread.UncaughtExceptionHandler-).



